### PR TITLE
Fix missing import causing 500 error in cash deposit endpoint

### DIFF
--- a/backend/app/crud/portfolio_extended.py
+++ b/backend/app/crud/portfolio_extended.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from app.models import Portfolio, Holding, Asset
 from app.schemas import PortfolioUpdate
 from app.services.exchange_rate_service import get_exchange_rate_service
+from app.crud.portfolio import get_portfolio
 
 
 async def update_portfolio(db: AsyncSession, portfolio_id: int, portfolio_update: PortfolioUpdate) -> Optional[Portfolio]:


### PR DESCRIPTION
Added missing import of get_portfolio function in portfolio_extended.py. This was causing a NameError when attempting to deposit or withdraw cash, resulting in a 500 Internal Server Error.

The cash deposit/withdrawal endpoints now work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)