### PR TITLE
Fix cash deposit/withdrawal endpoints to use updated portfolio balance

### DIFF
--- a/backend/app/api/v1/transactions.py
+++ b/backend/app/api/v1/transactions.py
@@ -126,18 +126,21 @@ async def deposit_cash(
     )
 
     # Update portfolio cash balance
-    await update_portfolio_cash_balance(
+    updated_portfolio = await update_portfolio_cash_balance(
         db=db,
         portfolio_id=portfolio_id,
         amount=cash_in.amount,
         operation="add"
     )
 
+    if not updated_portfolio:
+        raise HTTPException(status_code=404, detail="Portfolio not found during update")
+
     return {
         "message": "Cash deposited successfully",
         "transaction_id": transaction.id,
         "amount": cash_in.amount,
-        "new_balance": portfolio.cash_balance + cash_in.amount
+        "new_balance": updated_portfolio.cash_balance
     }
 
 
@@ -182,18 +185,21 @@ async def withdraw_cash(
     )
 
     # Update portfolio cash balance
-    await update_portfolio_cash_balance(
+    updated_portfolio = await update_portfolio_cash_balance(
         db=db,
         portfolio_id=portfolio_id,
         amount=cash_in.amount,
         operation="subtract"
     )
 
+    if not updated_portfolio:
+        raise HTTPException(status_code=404, detail="Portfolio not found during update")
+
     return {
         "message": "Cash withdrawn successfully",
         "transaction_id": transaction.id,
         "amount": cash_in.amount,
-        "new_balance": portfolio.cash_balance - cash_in.amount
+        "new_balance": updated_portfolio.cash_balance
     }
 
 


### PR DESCRIPTION
Changes:
- Store the result of update_portfolio_cash_balance() call
- Use the updated portfolio's cash_balance in response instead of calculating it
- Add validation to ensure portfolio update succeeded
- This prevents returning stale cash balance values

🤖 Generated with [Claude Code](https://claude.com/claude-code)